### PR TITLE
Check for error on prepared statement creation

### DIFF
--- a/test/Integration/PreparedStatementTest.php
+++ b/test/Integration/PreparedStatementTest.php
@@ -261,8 +261,7 @@ class PreparedStatementTest extends TestCase
     {
         $this->expectException(PreparedStatementExecuteException::class);
         $this->expectExceptionMessageMatches("/^Catalog Error\: Table with name non\_existing\_table does not exist\!/");
-        $smtp = $this->db->preparedStatement('DROP TABLE non_existing_table');
-        $smtp->execute();
+        $this->db->preparedStatement('DROP TABLE non_existing_table');
     }
 
     public function testErrorNonExistingDatabase(): void


### PR DESCRIPTION
This checks the result of the `duckdb_prepare` C API call.

Relevant docs: https://duckdb.org/docs/stable/clients/c/prepared