### PR TITLE
core: update clibs to v1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=satur-io_duckdb-php&metric=alert_status&token=4a4bd82eff843d2b4a93bf4552b6db78e598ecfa)](https://sonarcloud.io/summary/new_code?id=satur-io_duckdb-php)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=satur-io_duckdb-php&metric=coverage)](https://sonarcloud.io/summary/new_code?id=satur-io_duckdb-php)
 [![Packagist Version](https://img.shields.io/packagist/v/satur.io/duckdb?style=flat&logo=packagist&logoColor=white)](https://packagist.org/packages/satur.io/duckdb)
-![DuckDB C API Version](https://img.shields.io/badge/DuckDB_C_API-v1.5.1-%23FFF100?logo=duckdb)
+![DuckDB C API Version](https://img.shields.io/badge/DuckDB_C_API-v1.5.2-%23FFF100?logo=duckdb)
 
 
 This package provides a [DuckDB](https://github.com/duckdb/duckdb) Client API for PHP.

--- a/config.php
+++ b/config.php
@@ -1,10 +1,10 @@
 <?php
 
-const DUCKDB_PHP_LIB_VERSION = '1.5.1';
+const DUCKDB_PHP_LIB_VERSION = '1.5.2';
 const DUCKDB_PHP_LIB_CHECKSUMS = [
-    'linux-amd64' => '21aec66a60eae1696270ba715a481ab066a88d99a62718d0577579ac1a7a4834',
-    'linux-arm64' => '203b58511255b37328d3c2673798552af84ea73a5b1e29e8e9e1813ffd3dd064',
-    'osx-universal' => 'd9dd723c59f8571202b468f6bf71d4555238544553dd1445e6c9ecb39f54c0f3',
-    'windows-amd64' => 'b85febb52a7b2e6d6891fcfffd8685ea974012f952cdc8dadef9c81e281d730d',
-    'windows-arm64' => 'faf0af74503f7037090b46cbb61fe0238c434670a5b883e5425ed1121110ae64',
+    'linux-amd64' => '4711438f0fdb04f0441803409bec5430b763d4f2ac3482c1f97cfa6b5ecb4c15',
+    'linux-arm64' => 'b4acbd9d871c99788c303af982f2e39325f28fd415f9a927d0a73e206f09e75d',
+    'osx-universal' => '524f3537330a1b747556a0c98b62a46865a3f48c7ead2b2035c62f1ad3e5ca8b',
+    'windows-amd64' => 'c60bd7deb0ef6c2d5c12a9765b93ed930c34b984d4db79104a8c2955bc57017d',
+    'windows-arm64' => '334d09335e06e32f957bb55d6d0178ccc935e4c1efc85274fc6eb0f6932fa6b0',
 ];

--- a/docs/md/installation.md
+++ b/docs/md/installation.md
@@ -115,7 +115,7 @@ mkdir ~/my-custom-dir
 
 Download C library, for example, for osx:
 ```shell
-curl -s -L https://github.com/duckdb/duckdb/releases/download/v1.5.1/libduckdb-osx-universal.zip -o /tmp/duckdb.zip && unzip /tmp/duckdb.zip && rm /tmp/duckdb.zip
+curl -s -L https://github.com/duckdb/duckdb/releases/download/v1.5.2/libduckdb-osx-universal.zip -o /tmp/duckdb.zip && unzip /tmp/duckdb.zip && rm /tmp/duckdb.zip
 ```
 
 Copy the library binary file:

--- a/docs/md/types.md
+++ b/docs/md/types.md
@@ -1,6 +1,6 @@
 ## Types
 
-From version 1.2.0 on the library supports all DuckDB file types.
+From version 1.2.0 on the library supports the DuckDB types in this table, including `TIME_NS` and `GEOMETRY` when the bundled C API defines them.
 
 | DuckDB Type              | SQL Type     | PHP Type                             |
 |--------------------------|--------------|--------------------------------------|
@@ -24,6 +24,7 @@ From version 1.2.0 on the library supports all DuckDB file types.
 | DUCKDB_TYPE_UHUGEINT     | UHUGEINT     | Saturio\DuckDB\Type\Math\LongInteger |
 | DUCKDB_TYPE_VARCHAR      | VARCHAR      | string                               |
 | DUCKDB_TYPE_BLOB         | BLOB         | Saturio\DuckDB\Type\Blob             |
+| DUCKDB_TYPE_GEOMETRY     | GEOMETRY     | Saturio\DuckDB\Type\Blob             |
 | DUCKDB_TYPE_TIMESTAMP_S  | TIMESTAMP_S  | Saturio\DuckDB\Type\Timestamp        |
 | DUCKDB_TYPE_TIMESTAMP_MS | TIMESTAMP_MS | Saturio\DuckDB\Type\Timestamp        |
 | DUCKDB_TYPE_TIMESTAMP_NS | TIMESTAMP_NS | Saturio\DuckDB\Type\Timestamp        |

--- a/header/linux-amd64/duckdb-ffi.h
+++ b/header/linux-amd64/duckdb-ffi.h
@@ -109,6 +109,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.
@@ -6224,6 +6226,22 @@ Registers a custom log storage for the logger.
 * @return Whether the registration was successful.
 */
  duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+ char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
 
 
 

--- a/header/linux-arm64/duckdb-ffi.h
+++ b/header/linux-arm64/duckdb-ffi.h
@@ -109,6 +109,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.
@@ -6224,6 +6226,22 @@ Registers a custom log storage for the logger.
 * @return Whether the registration was successful.
 */
  duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+ char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
 
 
 

--- a/header/osx-universal/duckdb-ffi.h
+++ b/header/osx-universal/duckdb-ffi.h
@@ -109,6 +109,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.
@@ -6224,6 +6226,22 @@ Registers a custom log storage for the logger.
 * @return Whether the registration was successful.
 */
  duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+ char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
 
 
 

--- a/header/windows-amd64/duckdb-ffi.h
+++ b/header/windows-amd64/duckdb-ffi.h
@@ -109,6 +109,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.
@@ -6224,6 +6226,22 @@ Registers a custom log storage for the logger.
 * @return Whether the registration was successful.
 */
  duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+ char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
 
 
 

--- a/header/windows-arm64/duckdb-ffi.h
+++ b/header/windows-arm64/duckdb-ffi.h
@@ -109,6 +109,8 @@ typedef enum DUCKDB_TYPE {
 	DUCKDB_TYPE_INTEGER_LITERAL = 38,
 	// duckdb_time_ns (nanoseconds)
 	DUCKDB_TYPE_TIME_NS = 39,
+	// GEOMETRY type, WKB blob
+	DUCKDB_TYPE_GEOMETRY = 40,
 } duckdb_type;
 
 //! An enum over the returned state of different functions.
@@ -6224,6 +6226,22 @@ Registers a custom log storage for the logger.
 * @return Whether the registration was successful.
 */
  duckdb_state duckdb_register_log_storage(duckdb_database database, duckdb_log_storage log_storage);
+
+//----------------------------------------------------------------------------------------------------------------------
+// Geometry Helpers
+//----------------------------------------------------------------------------------------------------------------------
+// DESCRIPTION:
+// Functions to operate on GEOMETRY types`.
+//----------------------------------------------------------------------------------------------------------------------
+
+/*!
+Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+Result must be freed with `duckdb_free`.
+
+* @param type The GEOMETRY type.
+* @return The CRS of the GEOMETRY type, or NULL if the type is not a GEOMETRY type.
+*/
+ char *duckdb_geometry_type_get_crs(duckdb_logical_type type);
 
 
 

--- a/src/Result/Vector.php
+++ b/src/Result/Vector.php
@@ -52,7 +52,7 @@ class Vector
             TypeC::DUCKDB_TYPE_TIMESTAMP_TZ => $this->cast(TypeC::DUCKDB_TYPE_TIMESTAMP),
             TypeC::DUCKDB_TYPE_UUID => $this->cast(TypeC::DUCKDB_TYPE_UHUGEINT),
             TypeC::DUCKDB_TYPE_ENUM => $this->cast(TypeC::{Type::from($this->ffi->enumInternalType($this->logicalType))->name}),
-            TypeC::DUCKDB_TYPE_BLOB, TypeC::DUCKDB_TYPE_BIT, TypeC::DUCKDB_TYPE_BIGNUM => $this->cast(TypeC::DUCKDB_TYPE_VARCHAR),
+            TypeC::DUCKDB_TYPE_BLOB, TypeC::DUCKDB_TYPE_BIT, TypeC::DUCKDB_TYPE_BIGNUM, TypeC::DUCKDB_TYPE_GEOMETRY => $this->cast(TypeC::DUCKDB_TYPE_VARCHAR),
             default => $this->cast($this->type),
         };
 
@@ -125,8 +125,13 @@ class Vector
 
     private function cast(TypeC $type): NativeCData
     {
+        $ffiElementType = match ($type) {
+            TypeC::DUCKDB_TYPE_GEOMETRY => 'duckdb_string_t',
+            default => $type->value,
+        };
+
         return $this->ffi->cast(
-            "{$type->value} *",
+            "{$ffiElementType} *",
             $this->ffi->vectorGetData($this->vector),
         );
     }
@@ -163,7 +168,7 @@ class Vector
             TypeC::DUCKDB_TYPE_UHUGEINT => $this->typeConverter->getHugeIntFromDuckDBHugeInt($data, unsigned: true),
             TypeC::DUCKDB_TYPE_UUID => $this->typeConverter->getUUIDFromDuckDBHugeInt($data),
             TypeC::DUCKDB_TYPE_ENUM => $this->typeConverter->getStringFromEnum($this->logicalType, $data),
-            TypeC::DUCKDB_TYPE_BLOB => $this->typeConverter->getBlobFromBlob($data),
+            TypeC::DUCKDB_TYPE_BLOB, TypeC::DUCKDB_TYPE_GEOMETRY => $this->typeConverter->getBlobFromBlob($data),
             TypeC::DUCKDB_TYPE_BIT => $this->typeConverter->getStringFromDuckDBBit($data),
             TypeC::DUCKDB_TYPE_BIGNUM => $this->typeConverter->getStringFromDuckDBBigNum($data),
             default => $data,

--- a/src/Type/Converter/GetDuckDBValue.php
+++ b/src/Type/Converter/GetDuckDBValue.php
@@ -62,7 +62,8 @@ trait GetDuckDBValue
                 Type::DUCKDB_TYPE_HUGEINT => $this->createFromHugeInt($value),
                 Type::DUCKDB_TYPE_UHUGEINT => $this->createFromUhugeInt($value),
                 Type::DUCKDB_TYPE_UUID => $this->createFromUUID($value),
-                Type::DUCKDB_TYPE_BLOB => $this->createFromBlob($value),
+                Type::DUCKDB_TYPE_BLOB,
+                Type::DUCKDB_TYPE_GEOMETRY => $this->createFromBlob($value),
                 Type::DUCKDB_TYPE_DECIMAL => $this->createFromScalar($value, Type::DUCKDB_TYPE_DOUBLE),
                 default => throw new UnsupportedTypeException("Unsupported type: {$type->name}"),
             };

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -82,4 +82,6 @@ enum Type: int
 
     // duckdb_time_ns (nanoseconds)
     case DUCKDB_TYPE_TIME_NS = 39;
+    // GEOMETRY (WKB blob)
+    case DUCKDB_TYPE_GEOMETRY = 40;
 }

--- a/src/Type/TypeC.php
+++ b/src/Type/TypeC.php
@@ -82,4 +82,6 @@ enum TypeC: string
 
     // duckdb_time_ns (nanoseconds)
     case DUCKDB_TYPE_TIME_NS = 'duckdb_time_ns';
+    // WKB blob; vectors use duckdb_string_t at the FFI layer (value must differ from VARCHAR)
+    case DUCKDB_TYPE_GEOMETRY = 'duckdb_geometry_wkb';
 }

--- a/test/Integration/AllTypesTest.php
+++ b/test/Integration/AllTypesTest.php
@@ -22,7 +22,7 @@ class AllTypesTest extends TestCase
     {
         $result = $this->db->query('SELECT * FROM test_all_types();');
 
-        self::assertEquals(55, $result->columnCount());
+        self::assertEquals(56, $result->columnCount());
         $jsonResult = json_encode(
             iterator_to_array($result->rows(columnNameAsKey: true)),
             flags: JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
@@ -32,7 +32,7 @@ class AllTypesTest extends TestCase
 
     private function getExpectedResult(): string
     {
-        return <<<JSON
+        return <<<'JSON'
 [
     {
         "bool": false,
@@ -49,7 +49,6 @@ class AllTypesTest extends TestCase
         "bignum": "-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368",
         "date": "-5877641-06-25",
         "time": "00:00:00.0",
-        "time_ns": "00:00:00.0",
         "timestamp": "-290308-12-22 00:00:00.0",
         "timestamp_s": "-290308-12-22 00:00:00.0",
         "timestamp_ms": "-290308-12-22 00:00:00.0",
@@ -65,7 +64,7 @@ class AllTypesTest extends TestCase
         "uuid": "00000000-0000-0000-0000-000000000000",
         "interval": "0 months 0 days 0 microseconds",
         "varchar": "🦆🦆🦆🦆🦆🦆",
-        "blob": "thisisalongblob\\\\x00withnullbytes",
+        "blob": "thisisalongblob\\x00withnullbytes",
         "bit": "0010001001011100010101011010111",
         "small_enum": "DUCK_DUCK_ENUM",
         "medium_enum": "enum_0",
@@ -177,7 +176,9 @@ class AllTypesTest extends TestCase
                 2,
                 3
             ]
-        ]
+        ],
+        "time_ns": "00:00:00.0",
+        "geometry": "\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F"
     },
     {
         "bool": true,
@@ -194,7 +195,6 @@ class AllTypesTest extends TestCase
         "bignum": "179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368",
         "date": "5881580-07-10",
         "time": "24:00:00.0",
-        "time_ns": "24:00:00.0",
         "timestamp": "294247-01-10 04:00:54.775806000",
         "timestamp_s": "294247-01-10 04:00:54.0",
         "timestamp_ms": "294247-01-10 04:00:54.775000000",
@@ -210,7 +210,7 @@ class AllTypesTest extends TestCase
         "uuid": "ffffffff-ffff-ffff-ffff-ffffffffffff",
         "interval": "999 months 999 days 999999999 microseconds",
         "varchar": "goo\u0000se",
-        "blob": "\\\\x00\\\\x00\\\\x00a",
+        "blob": "\\x00\\x00\\x00a",
         "bit": "10101",
         "small_enum": "GOOSE",
         "medium_enum": "enum_299",
@@ -414,7 +414,9 @@ class AllTypesTest extends TestCase
                 5,
                 6
             ]
-        ]
+        ],
+        "time_ns": "24:00:00.0",
+        "geometry": "\\x01\\x07\\x00\\x00\\x00\\x0D\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x01\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x04\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x14@\\x00\\x00\\x00\\x00\\x00\\x00\\x18@\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F\\x00\\x00\\x00\\x00\\x00\\x00\\xF8\\x7F\\x01\\x05\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x01\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x02\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x00\\x00\\x00\\x00\\x00\\x00\\x08@\\x01\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x06\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\xF0?\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x07\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x14@\\x00\\x00\\x00\\x00\\x00\\x00\\x18@\\x01\\x07\\x00\\x00\\x00\\x00\\x00\\x00\\x00"
     },
     {
         "bool": null,
@@ -431,7 +433,6 @@ class AllTypesTest extends TestCase
         "bignum": null,
         "date": null,
         "time": null,
-        "time_ns": null,
         "timestamp": null,
         "timestamp_s": null,
         "timestamp_ms": null,
@@ -504,7 +505,9 @@ class AllTypesTest extends TestCase
             null,
             null
         ],
-        "list_of_fixed_int_array": []
+        "list_of_fixed_int_array": [],
+        "time_ns": null,
+        "geometry": null
     }
 ]
 JSON;


### PR DESCRIPTION
# DuckDB 1.5.2 upgrade

Bumps the bundled DuckDB C library to **1.5.2**, adds support for the new **`GEOMETRY`** logical type, and aligns integration tests and docs with the release.

## Key changes

- **`core` / FFI:** Update `DUCKDB_PHP_LIB_VERSION`, zip checksums, README badge, and installation example URL; regenerate **`header/**`** from the 1.5.2 release (includes **`DUCKDB_TYPE_GEOMETRY = 40`** in the C enum).

- **`DUCKDB_TYPE_GEOMETRY`:** Map geometry vectors to the same read path as binary payloads: cast through `duckdb_string_t`, decode with **`getBlobFromBlob`**, and expose values as **`Saturio\DuckDB\Type\Blob`** (WKB bytes). **`TypeC`** uses a distinct enum backing value so it does not collide with **`VARCHAR`**; **`Vector::cast()`** maps that case to **`duckdb_string_t`** for FFI.

- **Prepared values:** **`GetDuckDBValue`** accepts **`DUCKDB_TYPE_GEOMETRY`** and reuses **`createFromBlob`** (same as **`BLOB`**).

- **Docs:** Document **`TIME_NS`** / **`GEOMETRY`** in `docs/md/types.md` and keep manual download instructions tied to **`DUCKDB_PHP_LIB_VERSION`** in `docs/md/installation.md`.

- **`test_all_types()`:** Refresh **`Integration\AllTypesTest`** expected JSON (56 columns, column order as returned by DuckDB, correct blob/geometry escaping) in the existing **`<<<'JSON'`** heredoc convention.

## Testing

- **`Integration\AllTypesTest`** updated for the extra column(s) and geometry WKB strings; expectations match **`json_encode()`** of live query results.

**Disclaimer:** This upgrade was assisted by AI (via Cursor).